### PR TITLE
added influx IQL query support

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,0 +1,15 @@
+[run]
+init_cmds = [
+  ["scripts/build.py","--clean","-v"],
+	["./build/influxdb-relay", "-v", "-config", "./config/influxdb-relay.conf"]
+]
+watch_all = true
+watch_dirs = [
+	"$WORKDIR",
+]
+watch_exts = [".go", ".toml"]
+build_delay = 1500
+cmds = [
+  ["scripts/build.py","--clean","-v"],
+	["./build/influxdb-relay","-v","-config","./config/influxdb-relay.conf"]
+]

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,8 @@ type HTTPConfig struct {
 	Outputs []HTTPOutputConfig `toml:"output"`
 
 	HealthTimeout int64 `toml:"health-timeout-ms"`
+
+	QueryRouterEndpointApi []string `toml:"query-router-endpoint-api"`
 }
 
 // HTTPOutputConfig represents the specification of an HTTP backend target
@@ -200,7 +202,7 @@ func LoadConfigFile(filename string) (Config, error) {
 	if err == nil {
 		for i, r := range cfg.HTTPRelays {
 			for j, b := range r.Outputs {
-				if b.Location[len(b.Location) - 1] == '/' {
+				if b.Location[len(b.Location)-1] == '/' {
 					cfg.HTTPRelays[i].Outputs[j].Endpoints = checkDoubleSlash(b.Endpoints)
 				}
 			}

--- a/relay/http_middlewares.go
+++ b/relay/http_middlewares.go
@@ -18,7 +18,7 @@ func allMiddlewares(h *HTTP, handlerFunc relayHandlerFunc) relayHandlerFunc {
 func (h *HTTP) logMiddleWare(next relayHandlerFunc) relayHandlerFunc {
 	return relayHandlerFunc(func(h *HTTP, w http.ResponseWriter, r *http.Request, start time.Time) {
 		if h.log {
-			h.logger.Println("got request on: " + r.URL.Path)
+			h.logger.Printf("got request on: %s  from :%s %s\n", r.URL.Path, r.RemoteAddr, r.Referer())
 		}
 		next(h, w, r, start)
 	})

--- a/relay/retry.go
+++ b/relay/retry.go
@@ -23,7 +23,7 @@ type Operation func() error
 // There is no delay between attempts of different operations.
 type retryBuffer struct {
 	buffering int32
-	flushing int32
+	flushing  int32
 
 	initialInterval time.Duration
 	multiplier      time.Duration
@@ -82,6 +82,10 @@ func (r *retryBuffer) post(buf []byte, query string, auth string, endpoint strin
 	return &responseData{StatusCode: http.StatusAccepted}, err
 }
 
+func (r *retryBuffer) query(inq *ifxQuery, endpoint string) (*http.Response, error) {
+	return nil, nil
+}
+
 func (r *retryBuffer) run() {
 	buf := bytes.NewBuffer(make([]byte, 0, r.maxBatch))
 	for {
@@ -105,8 +109,8 @@ func (r *retryBuffer) run() {
 				break
 			}
 
-      resp, err := r.p.post(buf.Bytes(), batch.query, batch.auth, batch.endpoint)
-      if err == nil && resp.StatusCode/100 != 5 {
+			resp, err := r.p.post(buf.Bytes(), batch.query, batch.auth, batch.endpoint)
+			if err == nil && resp.StatusCode/100 != 5 {
 				batch.resp = resp
 				atomic.StoreInt32(&r.buffering, 0)
 				batch.wg.Done()


### PR DESCRIPTION
Implements https://github.com/vente-privee/influxdb-relay/issues/24

Also added a query-router-endpoint-api parameter to get a list of available influx ID's to send /query queries.
Example:

````
query-router-endpoint-api= ["http://127.0.0.1:4090/api/queryactive","http://127.0.0.1:4090/api/queryactive"]
````

query-router-endpoint-api should be an array of valid url's which could all or any give us an array of  ID's identified as influxdb outputs with valid data .


example 

For this influxdb-config file.

````
[[http]]
name = "example-http-influxdb"
bind-addr = "0.0.0.0:9096"

query-router-endpoint-api= ["http://127.0.0.1:4090/api/queryactive","http://127.0.0.1:4090/api/queryactive"]



[[http.output]]
name = "influxdb01"
location = "http://127.0.0.1:8086/"
endpoints = {write="/write", write_prom="/api/v1/prom/write", ping="/ping", query="/query"}
timeout = "10s"

[[http.output]]
name = "influxdb02"
location = "http://127.0.0.1:8087/"
endpoints = {write="/write", write_prom="/api/v1/prom/write", ping="/ping", query="/query"}
timeout = "10s"
````


This should be the response for the endpoint ( in this case from syncflux)



````bash
>curl http://127.0.0.1:4090/api/queryactive
[
  "influxdb01",
  "influxdb02"
]
````

if not available any of the query-router-enpoints or not configured query will be sent on the first available backend ordered by the config  in this case first influxdb01 and if needed influxdb02 after.